### PR TITLE
print command being run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project uses [SemVer](https://semver.org/) for versioning. Its public APIs,
 _released `TBD`_
 
 - add django support (https://github.com/xavdid/universal-test-runner/pull/1)
+- print the command being run; disable by setting `UTR_DISABLE_ECHO` in the environment ()
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project uses [SemVer](https://semver.org/) for versioning. Its public APIs,
 _released `TBD`_
 
 - add django support (https://github.com/xavdid/universal-test-runner/pull/1)
-- print the command being run; disable by setting `UTR_DISABLE_ECHO` in the environment ()
+- print the command being run; disable by setting `UTR_DISABLE_ECHO` in the environment (https://github.com/xavdid/universal-test-runner/pull/2)
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Once installed, the command `t` will be available. Run it in a project folder's 
 
 ```
 % t
+-> pytest
 =============================== test session starts ================================
 platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
 rootdir: /Users/username/projects/test-runner
@@ -45,6 +46,7 @@ It passes all arguments and environment modifications down to the chosen test ru
 
 ```
 % t -k test_builder --verbose
+-> pytest -k test_builder --verbose
 =============================== test session starts ================================
 platform darwin -- Python 3.11.0, pytest-7.3.1, pluggy-1.0.0
 cachedir: .pytest_cache
@@ -55,6 +57,8 @@ tests/test_context.py::test_builder PASSED                                   [10
 
 ========================= 1 passed, 77 deselected in 0.03s =========================
 ```
+
+It prints the command it's running as part of the output. To disable that behavior, set `UTR_DISABLE_ECHO` to any value in the environment.
 
 If it can't guess the testing method, it will tell you so. Feel free to open an issue to request wider language support!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 keywords = ["testing", "test-runner", "pytest"]
 
-dependencies = ["click==8.1.3"]
+dependencies = ["click==8.1.3", "colorama==0.4.6"]
 
 [project.optional-dependencies]
 test = ["pytest==7.3.1", "responses==0.23.1", "pyright==1.1.309"]

--- a/universal_test_runner/runner.py
+++ b/universal_test_runner/runner.py
@@ -1,5 +1,8 @@
+import os
 import subprocess
 import sys
+
+from colorama import Style, just_fix_windows_console
 
 from universal_test_runner.context import Context
 from universal_test_runner.matchers import find_test_command
@@ -10,6 +13,9 @@ def run_test_command(command: list[str]) -> int:
         print("no testing method found!")
         return 1
 
+    if "UTR_DISABLE_ECHO" not in os.environ:
+        just_fix_windows_console()
+        print(Style.DIM + "-> " + " ".join(command) + Style.RESET_ALL)
     try:
         return subprocess.run(command).returncode
     except FileNotFoundError:


### PR DESCRIPTION
Respond to feedback and print the command that's being run for clarity. Disable this behavior with the `UTR_DISABLE_ECHO` environment variable.