### PR TITLE
Call `just --dump` to read justfile contents instead of reading file as text

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ _require-venv:
     import sys
     sys.exit(sys.prefix == sys.base_prefix)
 
-test *options:
+@test *options:
     pytest {{options}}
 
 @tox:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Optional, Protocol
 
@@ -49,3 +50,60 @@ def write_file(tmp_path: Path) -> FileWriterFunc:
         (tmp_path / filename).write_text(data)
 
     return _write
+
+
+@pytest.fixture
+def justfile_json() -> str:
+    return json.dumps(
+        {
+            "aliases": {},
+            "assignments": {},
+            "first": "default",
+            "recipes": {
+                "default": {
+                    "attributes": [],
+                    "body": [["just --list"]],
+                    "dependencies": [],
+                    "doc": None,
+                    "name": "default",
+                    "parameters": [],
+                    "priors": 0,
+                    "private": False,
+                    "quiet": False,
+                    "shebang": False,
+                },
+                "test": {
+                    "attributes": [],
+                    "body": [["pytest ", [["variable", "options"]]]],
+                    "dependencies": [],
+                    "doc": None,
+                    "name": "test",
+                    "parameters": [
+                        {
+                            "default": None,
+                            "export": False,
+                            "kind": "star",
+                            "name": "options",
+                        }
+                    ],
+                    "priors": 0,
+                    "private": False,
+                    "quiet": True,
+                    "shebang": False,
+                },
+            },
+            "settings": {
+                "allow_duplicate_recipes": False,
+                "dotenv_load": None,
+                "export": False,
+                "fallback": False,
+                "ignore_comments": False,
+                "positional_arguments": False,
+                "shell": None,
+                "tempdir": None,
+                "windows_powershell": False,
+                "windows_shell": None,
+            },
+            "warnings": [],
+        }
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Callable, Optional, Protocol
 
 import pytest
 
@@ -34,6 +34,9 @@ def build_context(tmp_path: Path, touch_files) -> ContextBuilderFunc:
         files: OptionalStrList = None, args: OptionalStrList = None, debugging=False
     ):
         touch_files(files or [])
+        # no need to clear cache here, since the unique-per-test
+        # (and params) tmp_path marks all contexts as separate items
+        # so, no interference
         return Context.build(str(tmp_path), args or [], debugging=debugging)
 
     return _build
@@ -53,57 +56,60 @@ def write_file(tmp_path: Path) -> FileWriterFunc:
 
 
 @pytest.fixture
-def justfile_json() -> str:
-    return json.dumps(
-        {
-            "aliases": {},
-            "assignments": {},
-            "first": "default",
-            "recipes": {
-                "default": {
-                    "attributes": [],
-                    "body": [["just --list"]],
-                    "dependencies": [],
-                    "doc": None,
-                    "name": "default",
-                    "parameters": [],
-                    "priors": 0,
-                    "private": False,
-                    "quiet": False,
-                    "shebang": False,
+def justfile_json() -> Callable[[str], str]:
+    def _justfile(recipe_name: str):
+        return json.dumps(
+            {
+                "aliases": {},
+                "assignments": {},
+                "first": "default",
+                "recipes": {
+                    "default": {
+                        "attributes": [],
+                        "body": [["just --list"]],
+                        "dependencies": [],
+                        "doc": None,
+                        "name": "default",
+                        "parameters": [],
+                        "priors": 0,
+                        "private": False,
+                        "quiet": False,
+                        "shebang": False,
+                    },
+                    recipe_name: {
+                        "attributes": [],
+                        "body": [["pytest ", [["variable", "options"]]]],
+                        "dependencies": [],
+                        "doc": None,
+                        "name": "test",
+                        "parameters": [
+                            {
+                                "default": None,
+                                "export": False,
+                                "kind": "star",
+                                "name": "options",
+                            }
+                        ],
+                        "priors": 0,
+                        "private": False,
+                        "quiet": True,
+                        "shebang": False,
+                    },
                 },
-                "test": {
-                    "attributes": [],
-                    "body": [["pytest ", [["variable", "options"]]]],
-                    "dependencies": [],
-                    "doc": None,
-                    "name": "test",
-                    "parameters": [
-                        {
-                            "default": None,
-                            "export": False,
-                            "kind": "star",
-                            "name": "options",
-                        }
-                    ],
-                    "priors": 0,
-                    "private": False,
-                    "quiet": True,
-                    "shebang": False,
+                "settings": {
+                    "allow_duplicate_recipes": False,
+                    "dotenv_load": None,
+                    "export": False,
+                    "fallback": False,
+                    "ignore_comments": False,
+                    "positional_arguments": False,
+                    "shell": None,
+                    "tempdir": None,
+                    "windows_powershell": False,
+                    "windows_shell": None,
                 },
-            },
-            "settings": {
-                "allow_duplicate_recipes": False,
-                "dotenv_load": None,
-                "export": False,
-                "fallback": False,
-                "ignore_comments": False,
-                "positional_arguments": False,
-                "shell": None,
-                "tempdir": None,
-                "windows_powershell": False,
-                "windows_shell": None,
-            },
-            "warnings": [],
-        }
-    )
+                "warnings": [],
+            }
+        )
+
+    return _justfile

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -151,3 +151,16 @@ def test_debugging_is_disableable(capsys, build_context: ContextBuilderFunc):
 
     out, _ = capsys.readouterr()
     assert out == ""
+
+
+def test_file_cache_hits(build_context: ContextBuilderFunc, write_file: FileWriterFunc):
+    write_file("package.json", "{}")
+    c = build_context(["package-lock.json", "yarn.lock", "pnpm-lock.yaml"])
+    c._load_file.cache_clear()
+
+    for _ in range(3):
+        c.read_json("package.json")
+
+    assert c._load_file.cache_info().currsize == 1
+    assert c._load_file.cache_info().hits == 2
+    assert c._load_file.cache_info().misses == 1

--- a/universal_test_runner/matchers.py
+++ b/universal_test_runner/matchers.py
@@ -85,12 +85,9 @@ def _matches_justfile(c: Context) -> bool:
             check=True,
         )
         file = json.loads(result.stdout)
-        return bool(file.get("recipes", {}).get("test"))
+        return "test" in file.get("recipes", {})
 
-    # TODO: uncomment the below after tests pass
-    # anything failing now has a live dependency on `just`, which is bad
     except (FileNotFoundError, subprocess.CalledProcessError):
-        # except subprocess.CalledProcessError:
         # either:
         # - just isn't installed
         # - something else went wrong (probably an invalid justfile)


### PR DESCRIPTION
Instead of parsing the justfile as text, use `just --dump --dump-format json` to get the file (if valid) in a pre-defined structure. This take a lot of the guesswork out, assuming the file is well-formed and `just` is installed.

It falls back to the text parsing if `just` is invalid. 