### PR TITLE
Better pytest detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project uses [SemVer](https://semver.org/) for versioning. Its public APIs,
 
 There may be breaking changes in minor releases before 1.0.0 and will be noted in these release notes.
 
+## 0.6.2
+
+_released `TBD`_
+
+- add better `pytest` detection in projects without a `.pytest-cache`
+
 ## 0.6.1
 
 _released `2024-08-14`_

--- a/README.md
+++ b/README.md
@@ -108,12 +108,13 @@ This list describes how each language behaves (but not the order in which langua
 
 - Python
   - checks for `manage.py` (Django)
-  - else tries to determine if you use `pytest`. It checks:
+  - else tries to determine if you use `pytest` in rough order of simplicity. It checks:
     - if you've got a `.pytest-cache` or `pytest.ini`
+    - if there's a `[pytest]` line in `tox.ini`
+    - if there's a `setup.cfg` and a `[tool:pytest]` line
     - otherwise, it tries to read `pyproject.toml`
       - if you're on Python 3.11+, it parses the file and checks for dependency [locations](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-optional-dependencies) [for](https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies) [popular](https://python-poetry.org/docs/managing-dependencies/#dependency-groups) [tools](https://pdm-project.org/latest/usage/dependency/#add-development-only-dependencies)
       - otherwise, it does a best-effort regex against the file contents, looking for `[tool.pytest.ini_options]` or [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers) like `pytest >= 2`
-    - if none of those worked, it lastly looks for `setup.cfg` and a `[tool:pytest]` key
   - looks for a `tests.py` file if not
 - Rust
   - `cargo test`

--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ This list describes how each language behaves (but not the order in which langua
 
 - Python
   - checks for `manage.py` (Django)
-  - else uses `pytest` if you've run `pytest` before. You'll need to run pytest manually on clean installs before `t` will work
+  - else tries to determine if you use `pytest`. It checks:
+    - if you've got a `.pytest-cache` or `pytest.ini`
+    - otherwise, it tries to read `pyproject.toml`
+      - if you're on Python 3.11+, it parses the file and checks for dependency [locations](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-optional-dependencies) [for](https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies) [popular](https://python-poetry.org/docs/managing-dependencies/#dependency-groups) [tools](https://pdm-project.org/latest/usage/dependency/#add-development-only-dependencies)
+      - otherwise, it does a best-effort regex against the file contents, looking for `[tool.pytest.ini_options]` or [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers) like `pytest >= 2`
+    - if none of those worked, it lastly looks for `setup.cfg` and a `[tool:pytest]` key
   - looks for a `tests.py` file if not
 - Rust
   - `cargo test`
@@ -161,7 +166,7 @@ error: Justfile does not contain recipes `-k` or `whatever`.
 
 That means your `test` recipe doesn't accept any options. Make sure it has an `*options` arg that you pass through to your test command:
 
-```makefile
+```justfile
 test *options:
     pytest {{options}}
 ```

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -226,7 +226,12 @@ class CommandFinderTestCase:
         CommandFinderTestCase(
             [],
             "pytest",
-            file_contents=[("setup.cfg", "[tool:pytest]\nneat")],
+            file_contents=[("setup.cfg", "[tool:pytest]\nminversion = 6.0")],
+        ),
+        CommandFinderTestCase(
+            [],
+            "pytest",
+            file_contents=[("tox.ini", "[pytest]\nminversion = 6.0")],
         ),
         CommandFinderTestCase(["manage.py"], "./manage.py test"),
         CommandFinderTestCase(["manage.py", ".pytest_cache"], "./manage.py test"),

--- a/universal_test_runner/commands.py
+++ b/universal_test_runner/commands.py
@@ -208,7 +208,7 @@ pytest = Command(
     "pytest",
     _matches_pytest,
     "pytest",
-    debug_line='looking for: a ".pytest_cache", pytest configuration files, or a a dependency on pytest (from any popular package manager)',
+    debug_line='looking for: a ".pytest_cache", pytest configuration files, or a dependency on pytest in "pyproject.toml" (from any popular package manager)',
 )
 py = Command.basic_builder("py", "tests.py", "python tests.py")
 django = Command.basic_builder("django", "manage.py", "./manage.py test")

--- a/universal_test_runner/commands.py
+++ b/universal_test_runner/commands.py
@@ -134,6 +134,14 @@ def _matches_pytest(c: Context) -> bool:
     if c.has_any_files(".pytest_cache", "pytest.ini"):
         return True
 
+    # https://docs.pytest.org/en/6.2.x/customize.html#tox-ini
+    if any(line == "[pytest]" for line in c.read_file("tox.ini")):
+        return True
+
+    # https://docs.pytest.org/en/6.2.x/customize.html#setup-cfg
+    if any(line == "[tool:pytest]" for line in c.read_file("setup.cfg")):
+        return True
+
     # pyproject has a lot of info by different bundlers
     if c.has_all_files(PYPROJECT_TOML):
         if pyproject := c.read_toml(PYPROJECT_TOML):
@@ -194,11 +202,6 @@ def _matches_pytest(c: Context) -> bool:
                 re.search(r"\"pytest ?[<=>]?", contents)
             ):
                 return True
-
-    # one last config spot
-    # https://docs.pytest.org/en/6.2.x/customize.html#pyproject-toml
-    if c.has_all_files("setup.cfg") and "[tool:pytest]" in c.read_file("setup.cfg"):
-        return True
 
     return False
 


### PR DESCRIPTION
While basic pytest detection has always worked great, it bothered me that it only worked _after_ you had run `pytest` before. On a fresh clone, there's not yet a cache, so the tool would fail-to-find. I wanted to do better. But, because of how fragmented Python packaging currently is, there's not a singe way to declare a dev dependency on `pytest`. 

I [asked on mastodon](https://mastodon.social/@xavdid/113104651324766527) and got some great responses for how to determine pytest usage. There are a few places people might write configuration, so those are good places to start. Failing that, there are a _finite_ number of ways pytest could show up in `pyproject.toml`, so I check all of those. It gets a little dicier on older Pythons that don't have `tomllib`, but it's not terrible.

Internally, I added a new file helper and changed the way reading missing files works (it fails more gracefully now).